### PR TITLE
Added support for a few more extruders

### DIFF
--- a/Duplicate.py
+++ b/Duplicate.py
@@ -72,7 +72,16 @@ class Duplicate(Extension):
                     Logger.log("d", "addMenuItem N°5")
                 if extruder_count > 5 :
                     self.addMenuItem(catalog.i18nc("@item:inmenu", "Duplicate Extruder N°6"), self.acTion6)
-                    Logger.log("d", "addMenuItem N°6")                    
+                    Logger.log("d", "addMenuItem N°6")      
+                if extruder_count > 6 :
+                    self.addMenuItem(catalog.i18nc("@item:inmenu", "Duplicate Extruder N°7"), self.acTion6)
+                    Logger.log("d", "addMenuItem N°7")   
+                if extruder_count > 7 :
+                    self.addMenuItem(catalog.i18nc("@item:inmenu", "Duplicate Extruder N°8"), self.acTion6)
+                    Logger.log("d", "addMenuItem N°8")   
+                if extruder_count > 8 :
+                    self.addMenuItem(catalog.i18nc("@item:inmenu", "Duplicate Extruder N°9"), self.acTion6)
+                    Logger.log("d", "addMenuItem N°9")   
                 self.acTionList()
         
     def acTionList(self) -> None:
@@ -98,8 +107,16 @@ class Duplicate(Extension):
 
     def acTion6(self) -> None:
         self.CopyExtrud(5)
-
         
+    def acTion7(self) -> None:
+        self.CopyExtrud(6)
+        
+    def acTion8(self) -> None:
+        self.CopyExtrud(7)
+
+    def acTion9(self) -> None:
+        self.CopyExtrud(8)
+    
     # Copy parameter form the ExtruderNb (Reference to the Other Extruder)
     def CopyExtrud(self,ExtruderNb) -> None:
  

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "Duplicate",
     "author": "5@xes",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "description": "Duplicate Extruder data",
     "api": 7,
     "supported_sdk_versions": ["7.0.0", "7.1.0", "7.2.0", "7.3.0", "7.4.0", "7.5.0", "7.6.0", "7.7.0", "7.8.0", "7.9.0", "8.0.0", "8.1.0", "8.2.0"]


### PR DESCRIPTION
I have a mixing head extruder and use 8 virtual extruders in Cura to manage the typical ratios I use when printing. This adds support for up to 9 extruders.

![image](https://github.com/5axes/Duplicate/assets/6918805/b84b56b9-2ec8-458a-9807-ef6090ae1f1b)
